### PR TITLE
finishing up api for requirements

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -252,6 +252,23 @@ class AuthorFriendsTestCase(TestCase):
         self.assertTrue("http://testserver/api/author/{}".format(self.author_A.pk)
                         in j["authors"])
 
+    def test_friend2friend(self):
+        j = self.c.get("/api/author/{}/friends/{}".format(
+            self.author_B.pk, self.author_A.pk
+        )).json()
+
+        self.assertEqual("friends", j["query"])
+        self.assertEqual(2, len(j["authors"]))
+        self.assertEqual(True, j["friends"])
+
+        j = self.c.get("/api/author/{}/friends/{}".format(
+            self.author_B.pk, self.author_C.pk
+        )).json()
+
+        self.assertEqual("friends", j["query"])
+        self.assertEqual(2, len(j["authors"]))
+        self.assertEqual(False, j["friends"])
+
     def test_post_query(self):
         j = self.c.post("/api/author/{}/friends".format(self.author_A.pk), {
             "query": "friends",

--- a/api/tests.py
+++ b/api/tests.py
@@ -137,6 +137,37 @@ class PostTestCase(TestCase):
         self.assertEqual("PUBLIC", act["visibility"])
         self.assertEqual(False, act["unlisted"])
 
+    def test_update_post(self):
+        post = Post.objects.create(date=datetime.date.today(),
+                                   title="a",
+                                   content="a",
+                                   author=self.author,
+                                   privacy=Privacy.PUBLIC)
+
+        resp = self.c.put("/api/posts/{}".format(post.pk), {
+            "title": "test",
+        }, content_type="application/json")
+        self.assertEqual(200, resp.status_code)
+
+        post.refresh_from_db()
+
+        self.assertEqual("test", post.title)
+        self.assertEqual("a", post.content)
+
+        resp = self.c.put("/api/posts/{}".format(post.pk), {
+            "content": "test",
+            "contentType": "text/markdown",
+        }, content_type="application/json")
+        self.assertEqual(200, resp.status_code)
+
+        post.refresh_from_db()
+
+        self.assertEqual("test", post.title)
+        self.assertEqual("test", post.content)
+        self.assertEqual("text/markdown", post.content_type)
+
+
+
     def test_create_post(self):
         resp = self.c.post("/api/posts", {
             "title": "test",

--- a/api/tests.py
+++ b/api/tests.py
@@ -252,6 +252,40 @@ class AuthorFriendsTestCase(TestCase):
         self.assertTrue("http://testserver/api/author/{}".format(self.author_A.pk)
                         in j["authors"])
 
+    def test_post_query(self):
+        j = self.c.post("/api/author/{}/friends".format(self.author_A.pk), {
+            "query": "friends",
+            "authors": []
+        }, content_type="application/json").json()
+
+        self.assertEqual(0, len(j["authors"]))
+
+        j = self.c.post("/api/author/{}/friends".format(self.author_A.pk), {
+            "query": "friends",
+            "authors": [
+                "http://testserver/api/author/{}".format(self.author_B.pk)
+            ]
+        }, content_type="application/json").json()
+
+        self.assertEqual(1, len(j["authors"]))
+        self.assertTrue("http://testserver/api/author/{}".format(self.author_B.pk)
+                        in j["authors"])
+
+        j = self.c.post("/api/author/{}/friends".format(self.author_A.pk), {
+            "query": "friends",
+            "authors": [
+                "http://testserver/api/author/{}".format(self.author_B.pk),
+                "http://testserver/api/author/{}".format(self.author_C.pk)
+            ]
+        }, content_type="application/json").json()
+
+        self.assertEqual(2, len(j["authors"]))
+        self.assertTrue("http://testserver/api/author/{}".format(self.author_B.pk)
+                        in j["authors"])
+        self.assertTrue("http://testserver/api/author/{}".format(self.author_C.pk)
+                        in j["authors"])
+
+
 
 class AuthorPostsTestCase(TestCase):
     def setUp(self):

--- a/api/urls.py
+++ b/api/urls.py
@@ -15,6 +15,8 @@ urlpatterns = [
          name="api_post_comments"),
     path('author/<int:author_id>/friends', views.author_friends,
          name="api_authorfriends"),
+    path('friends/<int:author_id>', views.author_friends,
+         name="api_stupidalias"),
     #TODO: re type author ids, this will not work with other nodes
     path('author/<int:author_id>/friends/<int:author_id2>',
          views.author_friendswith,

--- a/api/views.py
+++ b/api/views.py
@@ -251,7 +251,17 @@ def author_friends(request, author_id):
 
 @auth_api
 def author_friendswith(request, author_id, author_id2):
-    pass
+    author1 = get_object_or_404(Author, pk=author_id)
+    author2 = get_object_or_404(Author, pk=author_id2)
+
+    return JsonResponse({
+        "query": "friends",
+        "authors": [
+            api_reverse(request, "api_author", author_id=author1.pk),
+            api_reverse(request, "api_author", author_id=author2.pk),
+        ],
+        "friends": author1.friends_with(author2)
+    })
 
 
 def request_host(request):


### PR DESCRIPTION
- [x] friend querying via POSTs to http://service/friends/userid (this is likely wrong) (closes #79)
- [x] friend2friend querying via GETs to http://service/author/\<userid\>/friends/\<userid\> (closes #68)
- [x] implement author profiles via http://service/author/userid
- [x] Enforce some authentication
 - [x] implement a restful API for http://service/posts/postid (closes #78)

    a PUT should insert/update a post
    a POST should insert the post
    a GET with a postfixed “postid” should return the post
    a GET without a postfixed “postid” should return a list of all “PUBLIC” visibility posts on your node
    implement an alias http://service/posts/postid for Winter 2015 term projects.

- [x] friend requests can be made by POSTing a friend request to http://service/friendrequest
- [x] http://service/author/posts (posts that are visible to the currently authenticated user)
- [x] http://service/author/{AUTHOR_ID}/posts (all posts made by {AUTHOR_ID} visible to the currently authenticated user)